### PR TITLE
Handle 429 status codes in API responses

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 CHANGES
 =======
 
-* Add support for results
+* Add support for results get by test ID
 
 0.0.12
 ------

--- a/traw/__init__.py
+++ b/traw/__init__.py
@@ -13,6 +13,8 @@ The intended way to begin is to instantiate the TRAW Client:
 
 See the Client help documentation (`help(traw.Client)`) for more information
 """
+import logging
+
 from pbr.version import VersionInfo
 
 from .client import Client  # NOQA
@@ -20,3 +22,5 @@ from .client import Client  # NOQA
 
 __version__ = VersionInfo('traw').semantic_version().release_string()
 __all__ = ('__version__', 'Client')
+
+logging.getLogger(__package__).addHandler(logging.NullHandler())

--- a/traw/exceptions.py
+++ b/traw/exceptions.py
@@ -84,6 +84,25 @@ class NotFound(ResponseException):
     """Indicate that the requested URL was not found."""
 
 
+class RateLimited(ResponseException):
+    """Indicate the API rate limit was reached.
+
+    This class adds the attribute ``retry_after``, which is the number of seconds to
+    wait before retrying.
+
+    """
+
+    def __init__(self, response):
+        """Initialize a Redirect exception instance..
+
+        :param response: A requests.response instance containing a location
+        header.
+
+        """
+        super(RateLimited, self).__init__(response)
+        self.retry_after = int(response.headers['Retry-After'])
+
+
 class Redirect(ResponseException):
     """Indicate the request resulted in a redirect.
 


### PR DESCRIPTION
 - Handle 429 status codes from the API
 - Extract 'Retry-After' from the header, and sleep for that
   amount of time