### PR TITLE
Update run cases access and caching

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,15 @@
 CHANGES
 =======
 
+0.1.0
+-----
+
 * Add get cases filters
 * Add get cases support
+
+0.0.14
+------
+
 * Add section support for client and API
 * Add Section model
 * Add/update case model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,3 +28,11 @@ def client():
         api_mock.return_value = api_mock
 
         yield traw.Client(username=USER, password=PASS, url=URL)
+
+
+@pytest.fixture()
+def full_client():
+    with mock.patch('traw.api.Session') as sess_mock:
+        sess_mock.return_value = sess_mock
+
+        yield traw.Client(username=USER, password=PASS, url=URL)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -251,7 +251,7 @@ def test_add_run_with_case_ids(client):
     assert response.id == RUN_ID
     assert client.api.run_add.called
     assert 'mock name' in str(client.api.run_add.call_args)
-    assert '1,2,3,4' in str(client.api.run_add.call_args)
+    assert '[1, 2, 3, 4]' in str(client.api.run_add.call_args)
     assert 'extra' not in str(client.api.run_add.call_args)
 
 

--- a/traw/client.py
+++ b/traw/client.py
@@ -232,7 +232,7 @@ class Client(object):
         :yields: models.CaseType Objects
 
         """
-        for case_type in self.api.case_types():
+        for case_type in list(self.api.case_types()):
             yield models.CaseType(self, case_type)
 
     # Config related methods
@@ -499,7 +499,7 @@ class Client(object):
 
         :yields: models.Priority Objects
         """
-        for priority in self.api.priorities():
+        for priority in list(self.api.priorities()):
             yield models.Priority(self, priority)
 
     # Project related methods
@@ -557,7 +557,7 @@ class Client(object):
         else:
             is_completed = None
 
-        for project in self.api.projects(is_completed):
+        for project in list(self.api.projects(is_completed)):
             yield models.Project(self, project)
 
     # Result related methods
@@ -915,7 +915,7 @@ class Client(object):
 
         :yields: models.Status Objects
         """
-        for status in self.api.statuses():
+        for status in list(self.api.statuses()):
             yield models.Status(self, status)
 
     # Suite related methods
@@ -1029,7 +1029,7 @@ class Client(object):
 
     @templates.register(int)
     def _templates_by_project_id(self, project_id):
-        for template in self.api.templates(project_id):
+        for template in list(self.api.templates(project_id)):
             yield models.Template(self, template)
 
     @templates.register(models.Project)
@@ -1091,7 +1091,7 @@ class Client(object):
             with_status = with_status if isinstance(with_status, Iterable) else (with_status, )
             with_status = ','.join([str(s.id) for s in with_status])
 
-        for test in self.api.tests_by_run_id(run_id, with_status):
+        for test in list(self.api.tests_by_run_id(run_id, with_status)):
             yield models.Test(self, test)
 
     @tests.register(models.Run)
@@ -1138,7 +1138,7 @@ class Client(object):
 
         :yields: models.User Objects
         """
-        for user in self.api.users():
+        for user in list(self.api.users()):
             yield models.User(self, user)
 
     # Cache control related methods
@@ -1201,6 +1201,7 @@ class Client(object):
     def _clear_cache_case(self, _):
         """ Clear cache for models.Case related API methods """
         self.api.case_by_id.cache.clear()
+        self.api.cases_by_project_id.cache.clear()
 
     @clear_cache.register(models.CaseType)
     def _clear_cache_case_types(self, _):

--- a/traw/models/run.py
+++ b/traw/models/run.py
@@ -33,8 +33,6 @@ class Run(Addable, Closeable, Deleteable, Updatable, ModelBase):
 
         if fields['case_ids'] is None or fields['case_ids'] == list():
             fields.pop('case_ids')
-        else:
-            fields['case_ids'] = ','.join(map(str, fields['case_ids']))
 
         return fields
 


### PR DESCRIPTION
 - Update `client.add(run)` to correctly post case IDs as an array,
   rather than as a comma separated string
 - Update caching of generator yielded values to only cache results
   when the generator has been exhaussted