### PR TITLE
Update exception raising and handling

### DIFF
--- a/traw/exceptions.py
+++ b/traw/exceptions.py
@@ -55,9 +55,17 @@ class ResponseException(TRAWException):
         :param response: A requests.response instance.
 
         """
+        msg = ('Received {0} ({1}) HTTP response\n'
+               'With message: {2}\n'
+               'For request: {3}')
+        msg = msg.format(response.status_code, response.reason,
+                         response.content, response.request.path_url)
+
+        if hasattr(response.request, 'body') and response.request.body:
+            msg += '\nWith Request Body: {0}'.format(response.request.body)
+
         self.response = response
-        super(ResponseException, self).__init__('received {} HTTP response'
-                                                .format(response.status_code))
+        super(ResponseException, self).__init__(msg)
 
 
 class BadRequest(ResponseException):
@@ -126,6 +134,10 @@ class Redirect(ResponseException):
 
 
 class ServerError(ResponseException):
+    """Indicate issues on the server end preventing request fulfillment."""
+
+
+class ServiceUnavailableError(ResponseException):
     """Indicate issues on the server end preventing request fulfillment."""
 
 

--- a/traw/sessions.py
+++ b/traw/sessions.py
@@ -9,7 +9,8 @@ from requests.exceptions import ChunkedEncodingError, ConnectionError
 
 from .const import BASE_API_PATH, TIMEOUT
 from .exceptions import (BadRequest, Conflict, Forbidden, NotFound, RateLimited,
-                         Redirect, ServerError, TooLarge, UnknownStatusCode)
+                         Redirect, ServerError, ServiceUnavailableError,
+                         TooLarge, UnknownStatusCode)
 
 log = logging.getLogger(__package__)
 
@@ -27,7 +28,7 @@ class Session(object):
                          codes['internal_server_error']: ServerError,
                          codes['not_found']: NotFound,
                          codes['request_entity_too_large']: TooLarge,
-                         codes['service_unavailable']: ServerError,
+                         codes['service_unavailable']: ServiceUnavailableError,
                          codes['unauthorized']: Forbidden}
     SUCCESS_STATUSES = {codes['created'], codes['ok']}
 
@@ -66,6 +67,7 @@ class Session(object):
         else:
             return response, None
 
+    @retry(ServiceUnavailableError, tries=17, delay=1, backoff=2)
     @retry(RETRY_EXCEPTIONS, tries=3, delay=1, backoff=2)
     def _request_with_retries(self, *args, **kwargs):
         """  """


### PR DESCRIPTION
 - Catch and retry Service Unavailable errors. Start with a 1 second
   delay and 2X backoff for each attempt, for up to 32,768 seconds.
   Reraise Service Unavailable error after exhausting retry attempts
 - Update exception messages with additional information